### PR TITLE
fix: add posix `nxdomain` error

### DIFF
--- a/src/mug.gleam
+++ b/src/mug.gleam
@@ -46,6 +46,7 @@ pub type Error {
   Ewouldblock
   Exbadport
   Exbadseq
+  Nxdomain
   // https://www.erlang.org/doc/man/file#type-posix
   Eacces
   Eagain

--- a/test/mug_test.gleam
+++ b/test/mug_test.gleam
@@ -35,6 +35,13 @@ fn connect() -> mug.Socket {
   socket
 }
 
+pub fn connect_invalid_host_test() {
+  let assert Error(mug.Nxdomain) =
+    mug.new("invalid.example.com", port: port)
+    |> mug.timeout(milliseconds: 500)
+    |> mug.connect()
+}
+
 pub fn hello_world_test() {
   let socket = connect()
 


### PR DESCRIPTION
Fixes crash:

```
Failures:

  1) mug_test.connect_invalid_host_test
     #{function => <<"connect_invalid_host_test">>,gleam_error => let_assert,
       line => 39,message => <<"Assertion pattern match failed">>,
       module => <<"mug_test">>,
       value => {error,nxdomain}}
     location: mug_test.connect_invalid_host_test:39
     stacktrace:
       mug_test.connect_invalid_host_test
     output:
```
