### PR TITLE
Add receive_exact function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.0 - Unreleased
+
+- Added `receive_exact` function, to receive specific number of bytes.
+
 ## v1.0.0 - 2024-02-29
 
 - Fixed a bug where invalid domains could cause a crash.

--- a/src/mug.gleam
+++ b/src/mug.gleam
@@ -198,6 +198,24 @@ pub fn receive(
   gen_tcp_receive(socket, 0, timeout_milliseconds: timeout)
 }
 
+/// Receive the specified number of bytes from the client, unless the socket
+/// was closed, from the other side. In that case, the last read may return
+/// less bytes.
+/// If the specified number of bytes is not available to read from the socket
+/// then the function will block until the bytes are available, or until the
+/// timeout is reached.
+/// This directly calls the underlying Erlang function `gen_tcp:recv/3`.
+///
+/// Errors if the socket is closed, if the timeout is reached, or if there is
+/// some other problem receiving the packet.
+pub fn receive_exact(
+  socket: Socket,
+  byte_size size: Int,
+  timeout_milliseconds timeout: Int,
+) -> Result(BitArray, Error) {
+  gen_tcp_receive(socket, size, timeout_milliseconds: timeout)
+}
+
 @external(erlang, "gen_tcp", "recv")
 fn gen_tcp_receive(
   socket: Socket,

--- a/test/mug_test.gleam
+++ b/test/mug_test.gleam
@@ -1,11 +1,11 @@
-import gleam/bytes_builder.{from_string as bits}
 import gleam/bit_array
-import gleam/otp/actor
+import gleam/bytes_builder.{from_string as bits}
 import gleam/erlang/process
+import gleam/option.{None}
+import gleam/otp/actor
 import gleam/string
 import gleeunit
 import gleeunit/should
-import gleam/option.{None}
 import glisten
 import mug
 
@@ -105,6 +105,20 @@ pub fn exact_bytes_receive_test() {
 
   let assert Ok(<<"Hello":utf8>>) = mug.receive_exact(socket, 5, 100)
   let assert Ok(<<"World":utf8>>) = mug.receive_exact(socket, 5, 100)
+
+  let assert Ok(_) = mug.shutdown(socket)
+
+  let assert Error(mug.Closed) = mug.receive_exact(socket, 5, 100)
+}
+
+pub fn exact_bytes_receive_not_enough_test() {
+  let socket = connect()
+
+  let assert Ok(Nil) = mug.send(socket, <<"Hello":utf8>>)
+  let assert Ok(Nil) = mug.send(socket, <<"Worl":utf8>>)
+
+  let assert Ok(<<"Hello":utf8>>) = mug.receive_exact(socket, 5, 100)
+  let assert Error(mug.Timeout) = mug.receive_exact(socket, 5, 100)
 
   let assert Ok(_) = mug.shutdown(socket)
 

--- a/test/mug_test.gleam
+++ b/test/mug_test.gleam
@@ -96,3 +96,17 @@ pub fn active_mode_test() {
   let assert Ok(<<"Hello, Mike!\n":utf8>>) = mug.receive(socket, 0)
   let assert Error(mug.Timeout) = mug.receive(socket, 0)
 }
+
+pub fn exact_bytes_receive_test() {
+  let socket = connect()
+
+  let assert Ok(Nil) = mug.send(socket, <<"Hello":utf8>>)
+  let assert Ok(Nil) = mug.send(socket, <<"World":utf8>>)
+
+  let assert Ok(<<"Hello":utf8>>) = mug.receive_exact(socket, 5, 100)
+  let assert Ok(<<"World":utf8>>) = mug.receive_exact(socket, 5, 100)
+
+  let assert Ok(_) = mug.shutdown(socket)
+
+  let assert Error(mug.Closed) = mug.receive_exact(socket, 5, 100)
+}


### PR DESCRIPTION
Add `receive_exact` function, a direct abstraction over the Erlang `gen_tcp:recv/3`.

Closes #5 