### PR TITLE
Issue 8 handle unix sockets

### DIFF
--- a/src/mug.gleam
+++ b/src/mug.gleam
@@ -165,7 +165,7 @@ type ActiveValue {
 type GenTcpOption =
   #(GenTcpOptionName, Dynamic)
 
-@external(erlang, "gen_tcp", "connect")
+@external(erlang, "mug_ffi", "connect")
 fn gen_tcp_connect(
   host: Charlist,
   port: Int,

--- a/src/mug.gleam
+++ b/src/mug.gleam
@@ -100,6 +100,10 @@ pub type Error {
 pub type ConnectionOptions {
   ConnectionOptions(
     /// The hostname of the server to connect to.
+    ///
+    /// The hostname can be a string with a hostname, IP address or a unix socket
+    /// path. If the hostname starts with `/` or `@` it is treated as a unix socket
+    /// and abstract unix socket respectively.
     host: String,
     /// The port of the server to connect to.
     port: Int,

--- a/src/mug_ffi.erl
+++ b/src/mug_ffi.erl
@@ -1,6 +1,14 @@
 -module(mug_ffi).
 
--export([send/2, shutdown/1, coerce/1]).
+-export([connect/4, send/2, shutdown/1, coerce/1]).
+
+connect(Host0, Port0, Opts, Timeout) ->
+    {Host1, Port1} = case Host0 of
+        "/" ++ _Path -> {{local, Host0}, 0};
+        "@" ++ Path -> {{local, [0|Path]}, 0};
+        Host0 -> {Host0, Port0}
+    end,
+    gen_tcp:connect(Host1, Port1, Opts, Timeout).
 
 send(Socket, Packet) ->
     normalise(gen_tcp:send(Socket, Packet)).


### PR DESCRIPTION
This PR adds unix socket support to mug by treating hostnames beginning with `/` or `@` as unix socket. 

Because glisten doesn't support unix sockets either there is currently no tests. See #8 for other considerations.