### PR TITLE
Fix deprecations warnings from stdlib

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -4,7 +4,7 @@
 packages = [
   { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
   { name = "gleam_otp", version = "0.11.2", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "517FFB679E44AD71D059F3EF6A17BA6EFC8CB94FA174D52E22FB6768CF684D78" },
-  { name = "gleam_stdlib", version = "0.40.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86606B75A600BBD05E539EB59FABC6E307EEEA7B1E5865AFB6D980A93BCB2181" },
+  { name = "gleam_stdlib", version = "0.45.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "206FCE1A76974AECFC55AEBCD0217D59EDE4E408C016E2CFCCC8FF51278F186E" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "glisten", version = "5.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], otp_app = "glisten", source = "hex", outer_checksum = "48EF7F6D1DCA877C2F49AF35CC33946C7129EEB05A114758A2CC569C708BFAF8" },
   { name = "logging", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "1098FBF10B54B44C2C7FDF0B01C1253CAFACDACABEFB4B0D027803246753E06D" },

--- a/src/mug.gleam
+++ b/src/mug.gleam
@@ -1,4 +1,4 @@
-import gleam/bytes_builder.{type BytesBuilder}
+import gleam/bytes_tree.{type BytesTree}
 import gleam/dynamic.{type Dynamic}
 import gleam/erlang/atom
 import gleam/erlang/charlist.{type Charlist}
@@ -176,7 +176,7 @@ fn gen_tcp_connect(
 /// Send a packet to the client.
 ///
 pub fn send(socket: Socket, packet: BitArray) -> Result(Nil, Error) {
-  send_builder(socket, bytes_builder.from_bit_array(packet))
+  send_builder(socket, bytes_tree.from_bit_array(packet))
 }
 
 /// Send a packet to the client, the data in `BytesBuilder`. Using this function
@@ -184,7 +184,7 @@ pub fn send(socket: Socket, packet: BitArray) -> Result(Nil, Error) {
 /// `BitArray` to use with the `send` function.
 ///
 @external(erlang, "mug_ffi", "send")
-pub fn send_builder(socket: Socket, packet: BytesBuilder) -> Result(Nil, Error)
+pub fn send_builder(socket: Socket, packet: BytesTree) -> Result(Nil, Error)
 
 /// Receive a packet from the client.
 ///

--- a/test/mug_test.gleam
+++ b/test/mug_test.gleam
@@ -1,5 +1,5 @@
 import gleam/bit_array
-import gleam/bytes_builder.{from_string as bits}
+import gleam/bytes_tree.{from_string as bits}
 import gleam/erlang/process
 import gleam/option.{None}
 import gleam/otp/actor
@@ -16,7 +16,7 @@ pub fn main() {
   let assert Ok(_) =
     glisten.handler(fn(_) { #(Nil, None) }, fn(msg, state, conn) {
       let assert glisten.Packet(msg) = msg
-      let assert Ok(_) = glisten.send(conn, bytes_builder.from_bit_array(msg))
+      let assert Ok(_) = glisten.send(conn, bytes_tree.from_bit_array(msg))
       actor.continue(state)
     })
     |> glisten.serve(port)


### PR DESCRIPTION
This PR replaces use of the deprecated `gleam/bytes_builder` module to use the new `gleam/bytes_tree` module