### PR TITLE
Issue 8 handle unix sockets

### DIFF
--- a/src/mug.gleam
+++ b/src/mug.gleam
@@ -165,7 +165,7 @@ type ActiveValue {
 type GenTcpOption =
   #(GenTcpOptionName, Dynamic)
 
-@external(erlang, "gen_tcp", "connect")
+@external(erlang, "mug_ffi", "connect")
 fn gen_tcp_connect(
   host: Charlist,
   port: Int,

--- a/src/mug.gleam
+++ b/src/mug.gleam
@@ -100,6 +100,10 @@ pub type Error {
 pub type ConnectionOptions {
   ConnectionOptions(
     /// The hostname of the server to connect to.
+    ///
+    /// The hostname can be a string with a hostname, IP address or a unix socket
+    /// path. If the hostname starts with `/` or `@` it is treated as a unix socket
+    /// and abstract unix socket respectively.
     host: String,
     /// The port of the server to connect to.
     port: Int,

--- a/src/mug_ffi.erl
+++ b/src/mug_ffi.erl
@@ -1,6 +1,14 @@
 -module(mug_ffi).
 
--export([send/2, shutdown/1, coerce/1]).
+-export([connect/4, send/2, shutdown/1, coerce/1]).
+
+connect(Host0, Port0, Opts, Timeout) ->
+    {Host1, Port1} = case Host0 of
+        "/" ++ _Path -> {{local, Host0}, 0};
+        "@" ++ Path -> {{local, [0|Path]}, 0};
+        Host0 -> {Host0, Port0}
+    end,
+    gen_tcp:connect(Host1, Port1, Opts, Timeout).
 
 send(Socket, Packet) ->
     normalise(gen_tcp:send(Socket, Packet)).

--- a/src/mug_ffi.erl
+++ b/src/mug_ffi.erl
@@ -1,14 +1,17 @@
 -module(mug_ffi).
 
--export([connect/4, send/2, shutdown/1, coerce/1]).
+-export([connect_ip/4, connect_socket/3, send/2, shutdown/1, coerce/1]).
 
-connect(Host0, Port0, Opts, Timeout) ->
-    {Host1, Port1} = case Host0 of
-        "/" ++ _Path -> {{local, Host0}, 0};
-        "@" ++ Path -> {{local, [0|Path]}, 0};
-        Host0 -> {Host0, Port0}
+connect_ip(Host, Port, Opts, Timeout) ->
+    gen_tcp:connect(Host, Port, Opts, Timeout).
+
+connect_socket(Host0, Opts, Timeout) ->
+    Host1 = case Host0 of
+        "/" ++ _Path -> {local, Host0};
+        "@" ++ Path -> {local, [0|Path]}
     end,
-    gen_tcp:connect(Host1, Port1, Opts, Timeout).
+    gen_tcp:connect(Host1, 0, Opts, Timeout).
+
 
 send(Socket, Packet) ->
     normalise(gen_tcp:send(Socket, Packet)).

--- a/src/mug_ffi.erl
+++ b/src/mug_ffi.erl
@@ -1,14 +1,14 @@
 -module(mug_ffi).
 
--export([connect_ip/4, connect_socket/3, send/2, shutdown/1, coerce/1]).
+-export([connect_network/4, connect_socket/3, send/2, shutdown/1, coerce/1]).
 
-connect_ip(Host, Port, Opts, Timeout) ->
+connect_network(Host, Port, Opts, Timeout) ->
     gen_tcp:connect(Host, Port, Opts, Timeout).
 
 connect_socket(Host0, Opts, Timeout) ->
     Host1 = case Host0 of
-        "/" ++ _Path -> {local, Host0};
-        "@" ++ Path -> {local, [0|Path]}
+        "@" ++ Path -> {local, [0|Path]};
+        _ -> {local, Host0}
     end,
     gen_tcp:connect(Host1, 0, Opts, Timeout).
 

--- a/test/mug_test.gleam
+++ b/test/mug_test.gleam
@@ -24,6 +24,8 @@ pub fn main() {
   gleeunit.main()
 }
 
+// IP / Hostname --------------------------------------------------------------------
+
 fn connect() -> mug.Socket {
   let assert Ok(socket) =
     mug.new("localhost", port: port)
@@ -113,6 +115,212 @@ pub fn exact_bytes_receive_test() {
 
 pub fn exact_bytes_receive_not_enough_test() {
   let socket = connect()
+
+  let assert Ok(Nil) = mug.send(socket, <<"Hello":utf8>>)
+  let assert Ok(Nil) = mug.send(socket, <<"Worl":utf8>>)
+
+  let assert Ok(<<"Hello":utf8>>) = mug.receive_exact(socket, 5, 100)
+  let assert Error(mug.Timeout) = mug.receive_exact(socket, 5, 100)
+
+  let assert Ok(_) = mug.shutdown(socket)
+
+  let assert Error(mug.Closed) = mug.receive_exact(socket, 5, 100)
+}
+
+// Unix Sockets ------------------------------------------------------------------------
+
+fn connect_unix_socket() -> mug.Socket {
+  let assert Ok(socket) =
+    mug.new_unix_socket("/run/mug-test/")
+    |> mug.timeout(milliseconds: 500)
+    |> mug.connect()
+  socket
+}
+
+pub fn connect_unix_socket_invalid_host_test() {
+  let assert Error(mug.Nxdomain) =
+    mug.new_unix_socket("invalid.example.com")
+    |> mug.timeout(milliseconds: 500)
+    |> mug.connect()
+}
+
+pub fn unix_socket_hello_world_test() {
+  let socket = connect_unix_socket()
+
+  // Nothing has been sent by the echo server yet, so we get a timeout if we try
+  // to receive a packet.
+  let assert Error(mug.Timeout) = mug.receive(socket, timeout_milliseconds: 0)
+
+  let assert Ok(Nil) = mug.send(socket, <<"Hello, Joe!\n":utf8>>)
+  let assert Ok(Nil) = mug.send(socket, <<"Hello, Mike!\n":utf8>>)
+  let assert Ok(Nil) = mug.send_builder(socket, bits("System still working?\n"))
+  let assert Ok(Nil) = mug.send_builder(socket, bits("Seems to be!"))
+
+  let assert Ok(packet) = mug.receive(socket, timeout_milliseconds: 100)
+  let assert Ok(packet) = bit_array.to_string(packet)
+  string.split(packet, "\n")
+  |> should.equal([
+    "Hello, Joe!", "Hello, Mike!", "System still working?", "Seems to be!",
+  ])
+
+  let assert Ok(_) = mug.shutdown(socket)
+
+  let assert Error(mug.Closed) = mug.send(socket, <<"One more thing!":utf8>>)
+  let assert Error(mug.Closed) = mug.receive(socket, timeout_milliseconds: 0)
+}
+
+pub fn unix_socket_active_mode_test() {
+  let socket = connect_unix_socket()
+
+  // Ask for the next packet to be sent as a message
+  mug.receive_next_packet_as_message(socket)
+
+  // The socket is in use, we can't receive from it directly
+  let assert Error(mug.Einval) = mug.receive(socket, 0)
+
+  // Send a message to the socket
+  let assert Ok(Nil) = mug.send(socket, <<"Hello, Joe!\n":utf8>>)
+
+  let selector =
+    process.new_selector()
+    |> mug.selecting_tcp_messages(fn(msg) { msg })
+
+  let assert Ok(mug.Packet(packet_socket, <<"Hello, Joe!\n":utf8>>)) =
+    process.select(selector, 100)
+
+  packet_socket
+  |> should.equal(socket)
+
+  // Send another packet
+  let assert Ok(Nil) = mug.send(socket, <<"Hello, Mike!\n":utf8>>)
+
+  // The socket is in passive mode, so we don't get another message.
+  let assert Error(Nil) = process.select(selector, 100)
+
+  // The socket is back in passive mode, we can receive from it directly again.
+  let assert Ok(<<"Hello, Mike!\n":utf8>>) = mug.receive(socket, 0)
+  let assert Error(mug.Timeout) = mug.receive(socket, 0)
+}
+
+pub fn unix_socket_exact_bytes_receive_test() {
+  let socket = connect_unix_socket()
+
+  let assert Ok(Nil) = mug.send(socket, <<"Hello":utf8>>)
+  let assert Ok(Nil) = mug.send(socket, <<"World":utf8>>)
+
+  let assert Ok(<<"Hello":utf8>>) = mug.receive_exact(socket, 5, 100)
+  let assert Ok(<<"World":utf8>>) = mug.receive_exact(socket, 5, 100)
+
+  let assert Ok(_) = mug.shutdown(socket)
+
+  let assert Error(mug.Closed) = mug.receive_exact(socket, 5, 100)
+}
+
+pub fn unix_socket_exact_bytes_receive_not_enough_test() {
+  let socket = connect_unix_socket()
+
+  let assert Ok(Nil) = mug.send(socket, <<"Hello":utf8>>)
+  let assert Ok(Nil) = mug.send(socket, <<"Worl":utf8>>)
+
+  let assert Ok(<<"Hello":utf8>>) = mug.receive_exact(socket, 5, 100)
+  let assert Error(mug.Timeout) = mug.receive_exact(socket, 5, 100)
+
+  let assert Ok(_) = mug.shutdown(socket)
+
+  let assert Error(mug.Closed) = mug.receive_exact(socket, 5, 100)
+}
+
+// Abstract Unix Sockets ------------------------------------------------------------------------
+
+fn connect_abstract_unix_socket() -> mug.Socket {
+  let assert Ok(socket) =
+    mug.new_unix_socket("@/run/mug-test-abstract/")
+    |> mug.timeout(milliseconds: 500)
+    |> mug.connect()
+  socket
+}
+
+pub fn abstract_unix_socket_connect_invalid_host_test() {
+  let assert Error(mug.Nxdomain) =
+    mug.new_unix_socket("invalid.example.com")
+    |> mug.timeout(milliseconds: 500)
+    |> mug.connect()
+}
+
+pub fn abstract_unix_socket_hello_world_test() {
+  let socket = connect_abstract_unix_socket()
+
+  // Nothing has been sent by the echo server yet, so we get a timeout if we try
+  // to receive a packet.
+  let assert Error(mug.Timeout) = mug.receive(socket, timeout_milliseconds: 0)
+
+  let assert Ok(Nil) = mug.send(socket, <<"Hello, Joe!\n":utf8>>)
+  let assert Ok(Nil) = mug.send(socket, <<"Hello, Mike!\n":utf8>>)
+  let assert Ok(Nil) = mug.send_builder(socket, bits("System still working?\n"))
+  let assert Ok(Nil) = mug.send_builder(socket, bits("Seems to be!"))
+
+  let assert Ok(packet) = mug.receive(socket, timeout_milliseconds: 100)
+  let assert Ok(packet) = bit_array.to_string(packet)
+  string.split(packet, "\n")
+  |> should.equal([
+    "Hello, Joe!", "Hello, Mike!", "System still working?", "Seems to be!",
+  ])
+
+  let assert Ok(_) = mug.shutdown(socket)
+
+  let assert Error(mug.Closed) = mug.send(socket, <<"One more thing!":utf8>>)
+  let assert Error(mug.Closed) = mug.receive(socket, timeout_milliseconds: 0)
+}
+
+pub fn abstract_unix_socket_active_mode_test() {
+  let socket = connect_abstract_unix_socket()
+
+  // Ask for the next packet to be sent as a message
+  mug.receive_next_packet_as_message(socket)
+
+  // The socket is in use, we can't receive from it directly
+  let assert Error(mug.Einval) = mug.receive(socket, 0)
+
+  // Send a message to the socket
+  let assert Ok(Nil) = mug.send(socket, <<"Hello, Joe!\n":utf8>>)
+
+  let selector =
+    process.new_selector()
+    |> mug.selecting_tcp_messages(fn(msg) { msg })
+
+  let assert Ok(mug.Packet(packet_socket, <<"Hello, Joe!\n":utf8>>)) =
+    process.select(selector, 100)
+
+  packet_socket
+  |> should.equal(socket)
+
+  // Send another packet
+  let assert Ok(Nil) = mug.send(socket, <<"Hello, Mike!\n":utf8>>)
+
+  // The socket is in passive mode, so we don't get another message.
+  let assert Error(Nil) = process.select(selector, 100)
+
+  // The socket is back in passive mode, we can receive from it directly again.
+  let assert Ok(<<"Hello, Mike!\n":utf8>>) = mug.receive(socket, 0)
+  let assert Error(mug.Timeout) = mug.receive(socket, 0)
+}
+
+pub fn abstract_unix_socket_exact_bytes_receive_test() {
+  let socket = connect_abstract_unix_socket()
+
+  let assert Ok(Nil) = mug.send(socket, <<"Hello":utf8>>)
+  let assert Ok(Nil) = mug.send(socket, <<"World":utf8>>)
+
+  let assert Ok(<<"Hello":utf8>>) = mug.receive_exact(socket, 5, 100)
+  let assert Ok(<<"World":utf8>>) = mug.receive_exact(socket, 5, 100)
+
+  let assert Ok(_) = mug.shutdown(socket)
+
+  let assert Error(mug.Closed) = mug.receive_exact(socket, 5, 100)
+}
+
+pub fn abstract_unix_socket_exact_bytes_receive_not_enough_test() {
+  let socket = connect_abstract_unix_socket()
 
   let assert Ok(Nil) = mug.send(socket, <<"Hello":utf8>>)
   let assert Ok(Nil) = mug.send(socket, <<"Worl":utf8>>)


### PR DESCRIPTION
Continuation of: https://github.com/lpil/mug/pull/9

Extra constructor in action: 
![image](https://github.com/user-attachments/assets/9619b598-c3ab-49e9-8a78-9a3fd174bddd)
 
I had it implemented as just setting port = 0 at first and then as an option but those didn't feel clear enough.

So I made a `UnixConnectionOptions` which is handled throughout the builder. 

As well as Dedicated tcp_connect functions; ip_tcp_connect and socket_tcp_connect respectively.
(the FFI is also split into hostname/ip and socket/abstract-socket)

There's also 2 extra copies of the existing tests, one for sockets and one for abstract sockets.
Those should only need the matching servers added to em. 
Either once glisten supports them or once someone that knows more about erlang writes one for the tests. 
