### PR TITLE
Update to newer stdlib, gleam_erlang, and glisten

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "26.0.2"
-          gleam-version: "1.4.0"
+          otp-version: "28"
+          gleam-version: "1.11.1"
           rebar3-version: "3"
-      - run: gleam format --check src test
       - run: gleam deps download
       - run: gleam test
+      - run: gleam format --check src test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## v1.3.0 - 2024-12-04
+## v2.0.0 - 2025-06-19
 
+- `selecting_tcp_messages` has been renamed to `select_tcp_messages`.
 - Updated for gleam_erlang v1.0.0.
 - Updated for gleam_stdlib v0.60.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.3.0 - 2024-12-04
+
+- Updated for gleam_erlang v1.0.0.
+- Updated for gleam_stdlib v0.60.0.
+
 ## v1.2.0 - 2024-12-04
 
 - Updated for gleam_stdlib v0.44.0.

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "mug"
-version = "1.2.0"
+version = "2.0.0"
 gleam = ">= 1.4.0"
 
 description = "A TCP client for Gleam!"

--- a/gleam.toml
+++ b/gleam.toml
@@ -9,8 +9,8 @@ links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
 gleam_stdlib = ">= 0.60.0 and < 2.0.0"
-gleam_erlang = ">= 1.0.0-rc1 and < 2.0.0"
+gleam_erlang = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.2.0 and < 2.0.0"
-glisten = { git = "git@github.com:rawhat/glisten.git", ref = "gleam-erlang-v1" }
+glisten = ">= 8.0.0 and < 9.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -8,10 +8,9 @@ repository = { type = "github", user = "lpil", repo = "mug" }
 links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-gleam_stdlib = ">= 0.44.0 and < 2.0.0"
-gleam_erlang = ">= 0.22.0 and < 1.0.0"
+gleam_stdlib = ">= 0.60.0 and < 2.0.0"
+gleam_erlang = ">= 1.0.0-rc1 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.2.0 and < 2.0.0"
-gleam_otp = ">= 0.14.1 and < 1.0.0"
-glisten = ">= 6.0.0 and < 7.0.0"
+glisten = { git = "git@github.com:rawhat/glisten.git", ref = "gleam-erlang-v1" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,18 +2,17 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_otp", version = "0.14.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "5A8CE8DBD01C29403390A7BD5C0A63D26F865C83173CF9708E6E827E53159C65" },
-  { name = "gleam_stdlib", version = "0.45.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "206FCE1A76974AECFC55AEBCD0217D59EDE4E408C016E2CFCCC8FF51278F186E" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
-  { name = "glisten", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], otp_app = "glisten", source = "hex", outer_checksum = "912132751031473CB38F454120124FFC96AF6B0EA33D92C9C90DB16327A2A972" },
+  { name = "gleam_erlang", version = "1.0.0-rc1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "6E0CF4E1F66E2C9226B7554589544F00F12CE14858440EB1BF7EFDACDE1BBC64" },
+  { name = "gleam_otp", version = "1.0.0-rc2", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "27138425316D9AACC4881CE56A8F2BDE98AC9FB669755BEF712F37CB79090EAF" },
+  { name = "gleam_stdlib", version = "0.60.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "621D600BB134BC239CB2537630899817B1A42E60A1D46C5E9F3FAE39F88C800B" },
+  { name = "gleeunit", version = "1.3.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "A7DD6C07B7DA49A6E28796058AA89E651D233B357D5607006D70619CD89DAAAB" },
+  { name = "glisten", version = "7.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], source = "git", repo = "git@github.com:rawhat/glisten.git", commit = "09534cb68ec9caace2f6913a16b868ca6bf6ef2d" },
   { name = "logging", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "1098FBF10B54B44C2C7FDF0B01C1253CAFACDACABEFB4B0D027803246753E06D" },
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.22.0 and < 1.0.0" }
-gleam_otp = { version = ">= 0.14.1 and < 1.0.0" }
-gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
+gleam_erlang = { version = ">= 1.0.0-rc1 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.60.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.2.0 and < 2.0.0" }
-glisten = { version = ">= 6.0.0 and < 7.0.0" }
+glisten = { git = "git@github.com:rawhat/glisten.git", ref = "gleam-erlang-v1" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,17 +2,17 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "1.0.0-rc1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "6E0CF4E1F66E2C9226B7554589544F00F12CE14858440EB1BF7EFDACDE1BBC64" },
-  { name = "gleam_otp", version = "1.0.0-rc2", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "27138425316D9AACC4881CE56A8F2BDE98AC9FB669755BEF712F37CB79090EAF" },
+  { name = "gleam_erlang", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "7E6A5234F927C4B24F8054AB1E4572206C41F9E6D5C6C02273CB7531E7E5CED0" },
+  { name = "gleam_otp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "7020E652D18F9ABAC9C877270B14160519FA0856EE80126231C505D719AD68DA" },
   { name = "gleam_stdlib", version = "0.60.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "621D600BB134BC239CB2537630899817B1A42E60A1D46C5E9F3FAE39F88C800B" },
   { name = "gleeunit", version = "1.3.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "A7DD6C07B7DA49A6E28796058AA89E651D233B357D5607006D70619CD89DAAAB" },
-  { name = "glisten", version = "7.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], source = "git", repo = "git@github.com:rawhat/glisten.git", commit = "09534cb68ec9caace2f6913a16b868ca6bf6ef2d" },
+  { name = "glisten", version = "8.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], otp_app = "glisten", source = "hex", outer_checksum = "17B3CC2E5093662404DDCF7C837D1CA093E5C436CE5F8A532F8EA0D12B5B2172" },
   { name = "logging", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "1098FBF10B54B44C2C7FDF0B01C1253CAFACDACABEFB4B0D027803246753E06D" },
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 1.0.0-rc1 and < 2.0.0" }
+gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.60.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.2.0 and < 2.0.0" }
-glisten = { git = "git@github.com:rawhat/glisten.git", ref = "gleam-erlang-v1" }
+glisten = { version = ">= 8.0.0 and < 9.0.0" }

--- a/src/mug.gleam
+++ b/src/mug.gleam
@@ -4,6 +4,7 @@ import gleam/erlang/atom
 import gleam/erlang/charlist.{type Charlist}
 import gleam/erlang/process
 
+/// A TCP socket, used to send and receive TCP messages.
 pub type Socket
 
 type DoNotLeak
@@ -174,20 +175,20 @@ fn gen_tcp_connect(
   timeout: Int,
 ) -> Result(Socket, Error)
 
-/// Send a packet to the client.
+/// Send a message to the client.
 ///
-pub fn send(socket: Socket, packet: BitArray) -> Result(Nil, Error) {
-  send_builder(socket, bytes_tree.from_bit_array(packet))
+pub fn send(socket: Socket, message: BitArray) -> Result(Nil, Error) {
+  send_builder(socket, bytes_tree.from_bit_array(message))
 }
 
-/// Send a packet to the client, the data in `BytesBuilder`. Using this function
+/// Send a message to the client, the data in `BytesBuilder`. Using this function
 /// is more efficient turning an `BytesBuilder` or a `StringBuilder` into a
 /// `BitArray` to use with the `send` function.
 ///
 @external(erlang, "mug_ffi", "send")
 pub fn send_builder(socket: Socket, packet: BytesTree) -> Result(Nil, Error)
 
-/// Receive a packet from the client.
+/// Receive a message from the client.
 ///
 /// Errors if the socket is closed, if the timeout is reached, or if there is
 /// some other problem receiving the packet.
@@ -224,7 +225,8 @@ fn gen_tcp_receive(
   timeout_milliseconds timeout: Int,
 ) -> Result(BitArray, Error)
 
-/// Close the socket, ensuring that any data buffered in the socket is flushed to the operating system kernel socket first.
+/// Close the socket, ensuring that any data buffered in the socket is flushed
+/// to the operating system kernel socket first.
 ///
 @external(erlang, "mug_ffi", "shutdown")
 pub fn shutdown(socket: Socket) -> Result(Nil, Error)
@@ -265,7 +267,7 @@ pub type TcpMessage {
 /// controls, rather than any specific one. If you wish to only handle messages
 /// from one socket then use one process per socket.
 ///
-pub fn selecting_tcp_messages(
+pub fn select_tcp_messages(
   selector: process.Selector(t),
   mapper: fn(TcpMessage) -> t,
 ) -> process.Selector(t) {

--- a/src/mug_ffi.erl
+++ b/src/mug_ffi.erl
@@ -1,6 +1,12 @@
 -module(mug_ffi).
 
--export([send/2, shutdown/1, coerce_tcp_message/1]).
+-export([send/2, shutdown/1, coerce_tcp_message/1, active_once/0, passive/0]).
+
+active_once() ->
+    once.
+
+passive() ->
+    false.
 
 send(Socket, Packet) ->
     normalise(gen_tcp:send(Socket, Packet)).

--- a/src/mug_ffi.erl
+++ b/src/mug_ffi.erl
@@ -1,6 +1,6 @@
 -module(mug_ffi).
 
--export([send/2, shutdown/1, coerce/1]).
+-export([send/2, shutdown/1, coerce_tcp_message/1]).
 
 send(Socket, Packet) ->
     normalise(gen_tcp:send(Socket, Packet)).
@@ -8,9 +8,18 @@ send(Socket, Packet) ->
 shutdown(Socket) ->
     normalise(gen_tcp:shutdown(Socket, read_write)).
 
-normalise(ok) -> {ok, nil};
-normalise({ok, T}) -> {ok, T};
-normalise({error, {timeout, _}}) -> {error, timeout};
-normalise({error, _} = E) -> E.
+normalise(ok) ->
+    {ok, nil};
+normalise({ok, T}) ->
+    {ok, T};
+normalise({error, {timeout, _}}) ->
+    {error, timeout};
+normalise({error, _} = E) ->
+    E.
 
-coerce(T) -> T.
+coerce_tcp_message({tcp, Socket, Data}) ->
+    {packet, Socket, Data};
+coerce_tcp_message({tcp_closed, Socket}) ->
+    {socket_closed, Socket};
+coerce_tcp_message({tcp_error, Socket, Error}) ->
+    {tcp_error, Socket, Error}.

--- a/test/mug_test.gleam
+++ b/test/mug_test.gleam
@@ -1,12 +1,13 @@
 import gleam/bit_array
 import gleam/bytes_tree.{from_string as bits}
+import gleam/erlang/atom
 import gleam/erlang/process
 import gleam/option.{None}
-import gleam/otp/actor
 import gleam/string
 import gleeunit
 import gleeunit/should
 import glisten
+import glisten/transport
 import mug
 
 pub const port = 64_793
@@ -14,10 +15,15 @@ pub const port = 64_793
 pub fn main() {
   // Start an echo TCP server for the tests to use
   let assert Ok(_) =
-    glisten.handler(fn(_) { #(Nil, None) }, fn(msg, state, conn) {
+    glisten.handler(fn(_) { #(Nil, None) }, fn(state, msg, conn) {
       let assert glisten.Packet(msg) = msg
-      let assert Ok(_) = glisten.send(conn, bytes_tree.from_bit_array(msg))
-      actor.continue(state)
+      // Close connection if we receive a null, otherwise echo back.
+      let assert Ok(_) = case msg {
+        <<0>> -> transport.shutdown(conn.transport, conn.socket)
+        _ -> glisten.send(conn, bytes_tree.from_bit_array(msg))
+      }
+
+      glisten.continue(state)
     })
     |> glisten.serve(port)
 
@@ -51,6 +57,8 @@ pub fn hello_world_test() {
   let assert Ok(Nil) = mug.send_builder(socket, bits("System still working?\n"))
   let assert Ok(Nil) = mug.send_builder(socket, bits("Seems to be!"))
 
+  // Allow some time to echo things back, to make the test more reliable
+  process.sleep(20)
   let assert Ok(packet) = mug.receive(socket, timeout_milliseconds: 100)
   let assert Ok(packet) = bit_array.to_string(packet)
   string.split(packet, "\n")
@@ -81,7 +89,7 @@ pub fn active_mode_test() {
     |> mug.selecting_tcp_messages(fn(msg) { msg })
 
   let assert Ok(mug.Packet(packet_socket, <<"Hello, Joe!\n":utf8>>)) =
-    process.select(selector, 100)
+    process.selector_receive(selector, 100)
 
   packet_socket
   |> should.equal(socket)
@@ -90,11 +98,47 @@ pub fn active_mode_test() {
   let assert Ok(Nil) = mug.send(socket, <<"Hello, Mike!\n":utf8>>)
 
   // The socket is in passive mode, so we don't get another message.
-  let assert Error(Nil) = process.select(selector, 100)
+  let assert Error(Nil) = process.selector_receive(selector, 100)
 
   // The socket is back in passive mode, we can receive from it directly again.
   let assert Ok(<<"Hello, Mike!\n":utf8>>) = mug.receive(socket, 0)
   let assert Error(mug.Timeout) = mug.receive(socket, 0)
+}
+
+pub fn active_mode_close_test() {
+  let socket = connect()
+
+  // Ask for the next packet to be sent as a message
+  mug.receive_next_packet_as_message(socket)
+
+  // Send a message indicate the socket should be closed
+  let assert Ok(Nil) = mug.send(socket, <<0>>)
+
+  let selector =
+    process.new_selector()
+    |> mug.selecting_tcp_messages(fn(msg) { msg })
+
+  let assert Ok(mug.SocketClosed(closed_socket)) =
+    process.selector_receive(selector, 100)
+
+  closed_socket
+  |> should.equal(socket)
+}
+
+pub fn active_mode_error_test() {
+  // Couldn't find a way to trigger an error with an actual TCP server,
+  // so we are sending the raw message to ourself instead to mock an error.
+  let socket = connect()
+  mug.receive_next_packet_as_message(socket)
+
+  let selector =
+    process.new_selector()
+    |> mug.selecting_tcp_messages(fn(msg) { msg })
+
+  raw_send(process.self(), #(atom.create("tcp_error"), socket, mug.Ehostdown))
+  let assert Ok(mug.TcpError(error_socket, mug.Ehostdown)) =
+    process.selector_receive(selector, 100)
+  error_socket |> should.equal(socket)
 }
 
 pub fn exact_bytes_receive_test() {
@@ -124,3 +168,6 @@ pub fn exact_bytes_receive_not_enough_test() {
 
   let assert Error(mug.Closed) = mug.receive_exact(socket, 5, 100)
 }
+
+@external(erlang, "erlang", "send")
+fn raw_send(pid: process.Pid, msg: a) -> Nil

--- a/test/mug_test.gleam
+++ b/test/mug_test.gleam
@@ -15,7 +15,7 @@ pub const port = 64_793
 pub fn main() {
   // Start an echo TCP server for the tests to use
   let assert Ok(_) =
-    glisten.handler(fn(_) { #(Nil, None) }, fn(state, msg, conn) {
+    glisten.new(fn(_conn) { #(Nil, None) }, fn(state, msg, conn) {
       let assert glisten.Packet(msg) = msg
       // Close connection if we receive a null, otherwise echo back.
       let assert Ok(_) = case msg {
@@ -25,7 +25,7 @@ pub fn main() {
 
       glisten.continue(state)
     })
-    |> glisten.serve(port)
+    |> glisten.start(port)
 
   gleeunit.main()
 }

--- a/test/mug_test.gleam
+++ b/test/mug_test.gleam
@@ -86,7 +86,7 @@ pub fn active_mode_test() {
 
   let selector =
     process.new_selector()
-    |> mug.selecting_tcp_messages(fn(msg) { msg })
+    |> mug.select_tcp_messages(fn(msg) { msg })
 
   let assert Ok(mug.Packet(packet_socket, <<"Hello, Joe!\n":utf8>>)) =
     process.selector_receive(selector, 100)
@@ -116,7 +116,7 @@ pub fn active_mode_close_test() {
 
   let selector =
     process.new_selector()
-    |> mug.selecting_tcp_messages(fn(msg) { msg })
+    |> mug.select_tcp_messages(fn(msg) { msg })
 
   let assert Ok(mug.SocketClosed(closed_socket)) =
     process.selector_receive(selector, 100)
@@ -133,7 +133,7 @@ pub fn active_mode_error_test() {
 
   let selector =
     process.new_selector()
-    |> mug.selecting_tcp_messages(fn(msg) { msg })
+    |> mug.select_tcp_messages(fn(msg) { msg })
 
   raw_send(process.self(), #(atom.create("tcp_error"), socket, mug.Ehostdown))
   let assert Ok(mug.TcpError(error_socket, mug.Ehostdown)) =


### PR DESCRIPTION
I'm opening this as a draft, because it currently depends on the gleam_erlang RC and an unreleased branch of glisten! However, once those are released, I think this should be ready to go, unless there are surprises.

Update dependencies to
* gleam_erlang 1.0.0-rc1
* gleam_stdlib 0.60.0
* A branch of glisten that works with the above

This required mostly changing decoding of the messages, which felt more complicated with the new `gleam/dynamic/decode` and it felt cleaner to move the renaming of the record variant to be in an Erlang function instead. There were also some `dynamic.from` calls that I didn't quite figure out what they should be replaced with.

Also adds test coverage for closing the socket from the servers side, and receiving a simulated error (didn't figure out how to get an actual error with glisten).