### PR TITLE
Add functions to toggle between active mode permanently

### DIFF
--- a/src/mug.gleam
+++ b/src/mug.gleam
@@ -245,6 +245,9 @@ type ModeValue {
 
 type ActiveValue
 
+@external(erlang, "mug_ffi", "active")
+fn active() -> ActiveValue
+
 @external(erlang, "mug_ffi", "passive")
 fn passive() -> ActiveValue
 
@@ -337,6 +340,27 @@ pub fn shutdown(socket: Socket) -> Result(Nil, Error)
 ///
 pub fn receive_next_packet_as_message(socket: Socket) -> Nil {
   set_socket_options(socket, [Active(active_once())])
+  Nil
+}
+
+/// Switch the socket to active mode, meaning that all packets received on
+/// the socket will be sent as Erlang messages to the socket owner's inbox.
+///
+/// See `receive_next_packet_as_message` for details.
+///
+pub fn receive_all_packets_as_messages(socket: Socket) -> Nil {
+  set_socket_options(socket, [Active(active())])
+  Nil
+}
+
+/// Switch the socket to passive mode, meaning that packets received on the 
+/// socket will no longer be sent as Erlang messages to the socket owner's inbox.
+///
+/// Cancels the effect of `receive_next_packet_as_message` or 
+/// `receive_all_packets_as_messages`, if they have been called.
+///
+pub fn stop_receiving_packets_as_messages(socket: Socket) -> Nil {
+  set_socket_options(socket, [Active(passive())])
   Nil
 }
 

--- a/src/mug_ffi.erl
+++ b/src/mug_ffi.erl
@@ -1,9 +1,12 @@
 -module(mug_ffi).
 
--export([send/2, shutdown/1, coerce_tcp_message/1, active_once/0, passive/0]).
+-export([send/2, shutdown/1, coerce_tcp_message/1, active_once/0, active/0, passive/0]).
 
 active_once() ->
     once.
+
+active() ->
+    true.
 
 passive() ->
     false.


### PR DESCRIPTION
Adds `receive_all_packets_as_messages` and `stop_receiving_packets_as_messages` for permanently toggling active mode.

This removes the need to call `receive_next_packet_as_message` every time after receiving a packet, if you want to be in active mode permanently.